### PR TITLE
README: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ inlineSourceMapComment(map, {block: true});
 Type: `Boolean`  
 Default: `false`
 
-Preserves `sourcesConteThe prefix string of basent` property.
+Preserves the `sourcesContent` property.
 
 ### inlineSourceMapComment.prefix
 


### PR DESCRIPTION
Looks like a "multiple cursors"-introduced typo :)
